### PR TITLE
Docker image push tag

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -60,6 +60,7 @@ pipeline:
       - ${DRONE_COMMIT_SHA}
     when:
       event: [push]
+      branch: master
       status: [success]
 
   auto-update-robot-tests-matrix:


### PR DESCRIPTION
In order to be able to run the test suite on each push to master I need to have a docker image available in the docker registry.
By adding a separate drone step to push a docker image on push to master tagged with the commit sha enables me to reference it in the execution of the test run.

Same is used in other projects like Kupfer: https://github.com/Humanitec/kupfer/blob/3fe19762707f98e7bab34d1ff7dc6e33cbb5bd1b/.drone.yml#L46